### PR TITLE
remove https dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "connectedbytcp",
   "dependencies": {
 	"util": "*",
-	"https": "*",
 	"libxml-to-js": "*",
 	"events": "*",
 	"nconf": "*",


### PR DESCRIPTION
this is a builtin nodejs module, removing this line prevents an npm error during install.
